### PR TITLE
NoClassDefFound when deploying via repo docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,5 +31,6 @@ services:
       - ./requiredaction/target/dasniko.keycloak-requiredaction.jar:/opt/keycloak/providers/requiredaction.jar
       - ./rest-endpoint/target/dasniko.keycloak-rest-endpoint.jar:/opt/keycloak/providers/rest-endpoint.jar
       - ./tokenmapper/target/dasniko.keycloak-tokenmapper.jar:/opt/keycloak/providers/tokenmapper.jar
+      - ./utils/target/dasniko.keycloak-keycloak-utils.jar:/opt/keycloak/providers/dasniko.keycloak-utils.jar
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Hello, @dasniko!
I hope you're doing well!

I'm making attempts to get a deep dive into how the keycloak extensions can be written and have found out your repository.
These examples are really great, thank you for them!

But I've got an issue while deploying these extensions via docker compose located in this repository.

After running: 
```shell
docker compose up
```
And requesting localhost:8080 I've got an internal error response with such container logs:
<details>
<summary> container logs </summary>
<code>
keycloak-extensions-demo  | 2025-02-22 19:47:41,936 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-2) Uncaught server error: java.lang.NoClassDefFoundError: de/keycloak/util/BuildDetails
keycloak-extensions-demo  |     at dasniko.keycloak.user.flintstones.FlintstonesUserStorageProviderFactory.getOperationalInfo(FlintstonesUserStorageProviderFactory.java:77)
keycloak-extensions-demo  |     at org.keycloak.services.resources.admin.info.ServerInfoAdminResource.setProviders(ServerInfoAdminResource.java:173)
keycloak-extensions-demo  |     at org.keycloak.services.resources.admin.info.ServerInfoAdminResource.getInfo(ServerInfoAdminResource.java:137)
keycloak-extensions-demo  |     at org.keycloak.services.resources.admin.info.ServerInfoAdminResource$quarkusrestinvoker$getInfo_fd914d9de6cd89b23b6835a1a8efa5ee385ef0df.invoke(Unknown Source)
keycloak-extensions-demo  |     at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
keycloak-extensions-demo  |     at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:141)
keycloak-extensions-demo  |     at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
keycloak-extensions-demo  |     at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:635)
keycloak-extensions-demo  |     at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2516)
keycloak-extensions-demo  |     at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2495)
keycloak-extensions-demo  |     at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1521)
keycloak-extensions-demo  |     at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:11)
keycloak-extensions-demo  |     at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:11)
keycloak-extensions-demo  |     at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
keycloak-extensions-demo  |     at java.base/java.lang.Thread.run(Thread.java:1583)
keycloak-extensions-demo  | Caused by: java.lang.ClassNotFoundException: de.keycloak.util.BuildDetails
keycloak-extensions-demo  |     at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
keycloak-extensions-demo  |     at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
keycloak-extensions-demo  |     at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
keycloak-extensions-demo  |     at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:114)
keycloak-extensions-demo  |     at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:72)
keycloak-extensions-demo  |     ... 15 more
keycloak-extensions-demo  | 
</code>
</details>

I found out that `keycloak-utils` is imported to the `flintstones-user-provider` with `scope=provided`, but the module itself is not added to the Keycloak runtime: https://github.com/dasniko/keycloak-extensions-demo/blob/130c82827d4bd7c2c13092fd14bc42fc8eed3a01/flintstones-userprovider/pom.xml#L37-L42

So, this PR just adds this keycloak-utils-jar to the runtime to troubleshoot the issue mentioned above.