### PR TITLE
chores(flintstones-client): align client impl with the defined API to …

### DIFF
--- a/flintstones-userprovider/src/main/java/dasniko/keycloak/user/flintstones/FlintstonesApiClient.java
+++ b/flintstones-userprovider/src/main/java/dasniko/keycloak/user/flintstones/FlintstonesApiClient.java
@@ -45,8 +45,7 @@ public class FlintstonesApiClient {
 	@SneakyThrows
 	public Integer usersCount() {
 		String url = String.format("%s/users/count", baseUrl);
-		String count = prepareGetRequest(url).asString();
-		return Integer.valueOf(count);
+		return prepareGetRequest(url).asJson().get("count").asInt();
 	}
 
 	@SneakyThrows

--- a/flintstones-userprovider/src/test/java/dasniko/keycloak/user/flintstones/FlintstonesUserStorageProviderTest.java
+++ b/flintstones-userprovider/src/test/java/dasniko/keycloak/user/flintstones/FlintstonesUserStorageProviderTest.java
@@ -236,4 +236,15 @@ public class FlintstonesUserStorageProviderTest extends TestBase {
 		assertThat(updatedWilma.getLastName(), is("Feuerstein"));
 	}
 
+	@Test
+	@Order(8)
+	void testUsersCount() {
+		Keycloak kcAdmin = keycloak.getKeycloakAdminClient();
+		UsersResource usersResource = kcAdmin.realm(REALM).users();
+
+		int actualCount = usersResource.count();
+
+		assertThat(actualCount, is(6));
+	}
+
 }


### PR DESCRIPTION
Hello!

As it is described in the flintstones server API endpoint `/users/count` returns JSON object with a `count` key:

impl: https://github.com/dasniko/keycloak-extensions-demo/blob/130c82827d4bd7c2c13092fd14bc42fc8eed3a01/flintstones-userprovider/src/main/java/dasniko/keycloak/user/flintstones/repo/FlintstonesApiServer.java#L118-L121
docs: https://github.com/dasniko/keycloak-extensions-demo/blob/130c82827d4bd7c2c13092fd14bc42fc8eed3a01/flintstones-userprovider/src/test/resources/user-api.yml#L108-L115

But the flintstones client parses the response like an integer

This PR is aligning the client implementation with the defined API
